### PR TITLE
Rename destroy! to purge; respect for FF13

### DIFF
--- a/lib/kamikakushi.rb
+++ b/lib/kamikakushi.rb
@@ -31,7 +31,7 @@ module Kamikakushi
     update_column(:deleted_at, self.deleted_at = nil)
   end
 
-  def destroy!
+  def purge
     destroy_without_kamikakushi
   end
 end

--- a/spec/kamikakushi_spec.rb
+++ b/spec/kamikakushi_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Kamikakushi do
   describe 'real delete' do
     it do
       expect {
-        post.destroy!
+        post.purge
         post.reload
       }.to raise_error(ActiveRecord::RecordNotFound)
     end


### PR DESCRIPTION
Avoid overriding [destory!](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-destroy-21)
